### PR TITLE
Add autofill + querying via the hash parameter, similar to a query parameter

### DIFF
--- a/scanner.js
+++ b/scanner.js
@@ -1,6 +1,24 @@
 document.addEventListener("DOMContentLoaded", function() {
   initScanner();
+
+  // if "#query=" was specified -- this will autofill & query that automatically.
+  submitHashParameter();
 });
+
+function submitHashParameter() {
+  if (window.location.hash.length > 0) {
+    // expected: "#query=hello.world" -> "query=hello.world"
+    const queryLikeString = window.location.hash.substr(1);
+    const parameters = new URLSearchParams(queryLikeString);
+    const queryParameter = parameters.get('query');
+    if (queryParameter !== null) {
+        let form = document.getElementById('search');
+        form.query.value = queryParameter;
+        // "click" the button to propagate a proper event to "submitSearch(...)".
+        form.search.click();
+    }
+  }
+}
 
 function initScanner() {
   window.resultField = document.getElementById('result');


### PR DESCRIPTION
The scanner page now accepts a "query string" via the URL's hash area, to allow for autofill + querying. "location.hash" was used instead of "location.query" to keep the query fully client-side and respect caching.

The page now accepts a query through the "query" named parameter in "hash", e.g.:

- `hxxps://[...]/scanner/#query=hello.world`
- `hxxps://[...]/scanner/index.html#query=hello.world`

This could really help with "label exploring" -- an addon could add a link in profiles to the label scanner with the query parameter filled in with that profile's handle, so the user could query all labels on a profile in one click.

---

I tested this locally with dev tools overrides, and all seems to work well.